### PR TITLE
[FIX] Added check for "Target Word" for card promotion

### DIFF
--- a/src/retirement.py
+++ b/src/retirement.py
@@ -81,7 +81,7 @@ class RetirementHandler:
                 self.r_total += 1
 
 
-        elif p_int and card.ivl > p_int:
+        elif p_int and card.ivl > p_int and note['Target Word'] != '':
 
             p_tag_required = d_conf.get('promotion_required_tag')
 


### PR DESCRIPTION
Card promotion logic didn't check if there was any "Target Word" as part of its card promotion logic. As such, it was possible for sentence-only cards to be "promoted" to vocab cards, and appear with blank card-front.

Tested locally on my own Anki and verified.