### PR TITLE
Enable hover-like behavior on AnkiMobile (iOS)

### DIFF
--- a/src/languages/de/card/support.html
+++ b/src/languages/de/card/support.html
@@ -262,10 +262,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/en/card/support.html
+++ b/src/languages/en/card/support.html
@@ -256,10 +256,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/es/card/support.html
+++ b/src/languages/es/card/support.html
@@ -257,10 +257,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/fr/card/support.html
+++ b/src/languages/fr/card/support.html
@@ -257,10 +257,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/ja/card/support.html
+++ b/src/languages/ja/card/support.html
@@ -682,10 +682,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/ko/card/support.html
+++ b/src/languages/ko/card/support.html
@@ -302,10 +302,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/pt/card/support.html
+++ b/src/languages/pt/card/support.html
@@ -257,10 +257,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/yue/card/support.html
+++ b/src/languages/yue/card/support.html
@@ -327,10 +327,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/zh_CN/card/support.html
+++ b/src/languages/zh_CN/card/support.html
@@ -325,10 +325,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());

--- a/src/languages/zh_TW/card/support.html
+++ b/src/languages/zh_TW/card/support.html
@@ -325,10 +325,15 @@ for (elem of word_elements) {
     if (!is_mobile) {
         elem.addEventListener('mouseleave', on_activeLeave);
     }
+    if (is_mobile) {
+        elem.addEventListener('click', on_activeEnter);
+        elem.classList.add('tappable');
+    }
 }
 
 if (is_mobile) {
-    document.body.addEventListener('click', on_closeAllActiveBody); 
+    document.body.addEventListener('click', on_closeAllActiveBody);       
+    document.body.classList.add('tappable'); 
 }
 
 }());


### PR DESCRIPTION
Because `hover` logic does not work on mobile, I suggest that `hover` objects be turned to `tappable` objects.

**[Source](https://docs.ankimobile.net/more.html)**
AnkiMobile documentation suggests allowing for clickable text via a `tappable` `elementList` added to a `click` `eventListener`. 

**Implementation**
I wrapped the above logic around the already present `is_mobile` `boolean` flag and made sure to add this fix to both the `on_activeEnter` and `on_closeAllActiveBody` methods. 

In testing on my iOS device for cards in Japanese, I was able to click the text to show furigana, and then close the furigana by clicking the body text. On my desktop, the regular hover logic still works as expected. 

I am unable to test if this works on AnkiDroid.