### PR TITLE
Add subp class to provide versions of subprocess that do not flash on Windows

### DIFF
--- a/src/lib/shared/pydub/audio_segment.py
+++ b/src/lib/shared/pydub/audio_segment.py
@@ -48,6 +48,23 @@ if sys.version_info >= (3, 0):
     StringIO = BytesIO
 
 
+# Migaku addition to prevent window flashing
+class subp:
+    if hasattr(subprocess, "STARTUPINFO"):
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+        @classmethod
+        def Popen(cls, *args, **kwargs):
+            return subprocess.Popen(*args, **kwargs, startupinfo=cls.startupinfo)
+
+    else:
+
+        @classmethod
+        def Popen(cls, *args, **kwargs):
+            return subprocess.Popen(*args, **kwargs)
+
+
 class ClassPropertyDescriptor(object):
     def __init__(self, fget, fset=None):
         self.fget = fget
@@ -649,7 +666,7 @@ class AudioSegment(object):
         log_conversion(conversion_command)
 
         with open(os.devnull, "rb") as devnull:
-            p = subprocess.Popen(
+            p = subp.Popen(
                 conversion_command,
                 stdin=devnull,
                 stdout=subprocess.PIPE,
@@ -828,7 +845,7 @@ class AudioSegment(object):
 
         log_conversion(conversion_command)
 
-        p = subprocess.Popen(
+        p = subp.Popen(
             conversion_command,
             stdin=stdin_parameter,
             stdout=subprocess.PIPE,
@@ -1062,7 +1079,7 @@ class AudioSegment(object):
 
         # read stdin / write stdout
         with open(os.devnull, "rb") as devnull:
-            p = subprocess.Popen(
+            p = subp.Popen(
                 conversion_command,
                 stdin=devnull,
                 stdout=subprocess.PIPE,

--- a/src/lib/shared/pydub/utils.py
+++ b/src/lib/shared/pydub/utils.py
@@ -4,9 +4,27 @@ import json
 import os
 import re
 import sys
+import subprocess
 from subprocess import Popen, PIPE
 from math import log, ceil
 from tempfile import TemporaryFile
+
+
+# Migaku addition to prevent window flashing
+class subp:
+    if hasattr(subprocess, "STARTUPINFO"):
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+        @classmethod
+        def Popen(cls, *args, **kwargs):
+            return subprocess.Popen(*args, **kwargs, startupinfo=cls.startupinfo)
+
+    else:
+
+        @classmethod
+        def Popen(cls, *args, **kwargs):
+            return subprocess.Popen(*args, **kwargs)
 
 
 # TEMPORARY FIX TO PREVENT ERROR POPUPS
@@ -290,7 +308,7 @@ def mediainfo_json(filepath, read_ahead_limit=-1):
             file.close()
 
     command = [prober, "-of", "json"] + command_args
-    res = Popen(command, stdin=stdin_parameter, stdout=PIPE, stderr=PIPE)
+    res = subp.Popen(command, stdin=stdin_parameter, stdout=PIPE, stderr=PIPE)
     output, stderr = res.communicate(input=stdin_data)
     output = output.decode("utf-8", "ignore")
     stderr = stderr.decode("utf-8", "ignore")
@@ -344,12 +362,12 @@ def mediainfo(filepath):
     command_args = ["-v", "quiet", "-show_format", "-show_streams", filepath]
 
     command = [prober, "-of", "old"] + command_args
-    res = Popen(command, stdout=PIPE)
+    res = subp.Popen(command, stdout=PIPE)
     output = res.communicate()[0].decode("utf-8")
 
     if res.returncode != 0:
         command = [prober] + command_args
-        output = Popen(command, stdout=PIPE).communicate()[0].decode("utf-8")
+        output = subp.Popen(command, stdout=PIPE).communicate()[0].decode("utf-8")
 
     rgx = re.compile(r"(?:(?P<inner_dict>.*?):)?(?P<key>.*?)\=(?P<value>.*?)$")
     info = {}
@@ -395,7 +413,7 @@ def cache_codecs(function):
 def get_supported_codecs():
     encoder = get_encoder_name()
     command = [encoder, "-codecs"]
-    res = Popen(command, stdout=PIPE, stderr=PIPE)
+    res = subp.Popen(command, stdout=PIPE, stderr=PIPE)
     output = res.communicate()[0].decode("utf-8")
     if res.returncode != 0:
         return []

--- a/src/migaku_connection/__init__.py
+++ b/src/migaku_connection/__init__.py
@@ -13,7 +13,7 @@ from .card_creator import CardCreator
 from .audio_condenser import AudioCondenser
 from .learning_status_handler import LearningStatusHandler
 from .profile_data_provider import ProfileDataProvider
-from .ffmpeg_manager import ProgramManager
+from .program_manager import ProgramManager
 from .info_provider import InfoProvider
 from .card_send import CardSender
 from .search_handler import SearchHandler

--- a/src/migaku_connection/program_manager.py
+++ b/src/migaku_connection/program_manager.py
@@ -12,6 +12,23 @@ from .. import util
 from .. import config
 
 
+# Migaku addition to prevent window flashing
+class subp:
+    if hasattr(subprocess, "STARTUPINFO"):
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+        @classmethod
+        def call(cls, *args, **kwargs):
+            return subprocess.check_call(*args, **kwargs, startupinfo=cls.startupinfo)
+
+    else:
+
+        @classmethod
+        def call(cls, *args, **kwargs):
+            return subprocess.check_call(*args, **kwargs)
+
+
 class ProgramManager(aqt.qt.QObject):
     BASE_DOWNLOAD_URI = "https://migaku-public-data.migaku.com/"
     lock = Lock()
@@ -41,7 +58,7 @@ class ProgramManager(aqt.qt.QObject):
 
     def call(self, *args, **kwargs):
         assert self.is_available()
-        return subprocess.call([self.program_path, *args], **kwargs)
+        return subp.call([self.program_path, *args], **kwargs)
 
     def make_available(self):
         # Attempt global installation
@@ -156,7 +173,7 @@ class ProgramManager(aqt.qt.QObject):
         if not path:
             return False
         try:
-            subprocess.call([path, "-version"])
+            subp.call([path, "-version"])
             self.program_path = path
             return True
         except OSError:


### PR DESCRIPTION
Fixes issue reported [here](https://discord.com/channels/752293144917180496/1121342466226933842/1121679484161101844) of cmd prompt flashing when creating cards on Windows.

There are other uses of `subprocess.{call,Popen}` which are used in the code, but I'm not sure they are triggered anywhere. Anyway these three cases are the worst offenders.