### PR TITLE
Fix/url encode image names

### DIFF
--- a/src/inplace_editor.py
+++ b/src/inplace_editor.py
@@ -274,12 +274,6 @@ class PasteHandler:
 
     # returns (html, isInternal)
     def _processMime(self, mime: QMimeData, extended: bool = False) -> Tuple[str, bool]:
-        # print("html=%s image=%s urls=%s txt=%s" % (
-        #     mime.hasHtml(), mime.hasImage(), mime.hasUrls(), mime.hasText()))
-        # print("html", mime.html())
-        # print("urls", mime.urls())
-        # print("text", mime.text())
-
         # try various content types in turn
         html, internal = self._processHtml(mime)
         if html:

--- a/src/migaku_connection/srs_import.py
+++ b/src/migaku_connection/srs_import.py
@@ -277,12 +277,10 @@ class SrsImportHandler(MigakuHTTPHandler):
         lang = data["lang"]
         mappings = data["mappings"]
         card_types = data["cardTypes"]
-        print(f"card_types: {card_types}")
         user_token = data["userToken"]
         srs_today = data["srsToday"]
         is_free_trial = data.get("isFreeTrial", False)
         free_trial_remaining_cards = data.get("freeTrialRemainingCards", 999999999)
-        print(f"free trial cards: {free_trial_remaining_cards}")
         debug = data.get("debug", False)
 
         card_ids = aqt.mw.col.findCards(f"did:{deck_id}")
@@ -338,8 +336,6 @@ class SrsImportHandler(MigakuHTTPHandler):
 
         else:
             card_ids = card_ids[offset : offset + limit]
-
-        print(f"card_ids: {card_ids}")
 
         srs_util.upload_data_size = 0
         media_gather = set()

--- a/src/migaku_connection/srs_util.py
+++ b/src/migaku_connection/srs_util.py
@@ -241,12 +241,10 @@ def _upload_media_single_attempt(fname, user_token, is_audio=False):
         raise Exception(f"upload failed, requests, {r.status_code}, {r.text}")
 
     upload_info = r.json()
+    file_path = upload_info["filePath"]
 
     global upload_data_size
     upload_data_size += len(data)
-
-    file_path = upload_info["filePath"]
-    print(f"uploaded {fname} to r2://{file_path}")
 
     return "r2://" + file_path
 


### PR DESCRIPTION
Should fix the issue mentioned [here]( https://discord.com/channels/752293144917180496/1153956143190786108)

I also removed some scattered print statements.
The important part was using `urllib.parse.quote`, to turn the picture name into a valid url string.

This can also be cherry picked upon the v49 version
