### PR TITLE
fix: put exisiting or maybe non-existing patch arg into rest param

### DIFF
--- a/src/anki_version.py
+++ b/src/anki_version.py
@@ -34,7 +34,7 @@ def get_state() -> VersionState:
     except ValueError:
         return VersionState.UNKNOWN
 
-    major, minor = version_tuple
+    major, minor, *rest = version_tuple
 
     if major <= 2:
         # Old versioning scheme


### PR DESCRIPTION
Third try... Honestly I wasn't aware that, something like this causes an error

```
a, b = [1,2,3] # Error!
```

I think with the rest param it should now work.