### PR TITLE
Fix/migaku japanese compat

### DIFF
--- a/src/editor/current_editor.py
+++ b/src/editor/current_editor.py
@@ -72,13 +72,16 @@ def add_cards_add_to_history(note):
 def get_add_cards_info(defaults=None):
     addcards = get_add_cards()
 
+    cur_model = aqt.mw.col.get_config("curModel")
+    cur_deck = aqt.mw.col.get_config("curDeck")
+
     if addcards:
         note = addcards["note"]
         tags = note.tags
 
         if defaults:
+            notetype = aqt.mw.col.models.get(defaults.notetype_id)
             notetype_id = defaults.notetype_id
-            notetype = aqt.mw.col.models.get(notetype_id)
             deck_id = defaults.deck_id
         else:
             notetype = note.note_type()
@@ -86,12 +89,14 @@ def get_add_cards_info(defaults=None):
             deck_id = get_current_deck_id()
 
     else:
-        notetype_id = int(get("migakuNotetypeId", aqt.mw.col.get_config("curModel")))
-        notetype = aqt.mw.col.models.get(notetype_id)
-        deck_id = int(get("migakuDeckId", aqt.mw.col.get_config("curDeck")))
+        notetype_id = int(get("migakuNotetypeId", cur_model))
+        notetype = aqt.mw.col.models.get(notetype_id) or aqt.mw.col.models.get(
+            cur_model
+        )
+        deck_id = int(get("migakuDeckId", cur_deck))
         tags = []
 
-    deck = aqt.mw.col.decks.get(deck_id)
+    deck = aqt.mw.col.decks.get(deck_id) or aqt.mw.col.decks.get(cur_deck)
     deck_name = deck["name"]
     notetype_name = notetype["name"]
     fields = get_migaku_fields(notetype)

--- a/src/languages/ja/card/support.html
+++ b/src/languages/ja/card/support.html
@@ -248,9 +248,7 @@
       let ret = [];
 
       // without workarounds for missing spaces: /{([^]*?)}|((\S*)\[(.*?)\](\S*))|([^ {]+)/gm
-      const syntax_re = RegExp(
-        /{([^]*?)}|(([^\[\]\s\{\}　]*)\[(.*?)\]([^\[\]\s\{\}　]*))|([^ \u00A0{]+)/gm
-      );
+      const syntax_re = /{([^]*?)}|(([^\[\]\s\{\}　]*)\[(.*?)\]([^\[\]\s\{\}　]*))|([^ \u00A0{　]+)/gm
 
       const ja_text_re = new RegExp(
         /[\u3041-\u3096\u30A0-\u30FF\u3400-\u4DB5\u4E00-\u9FCB\uF900-\uFA6A\u2E80-\u2FD5\uFF65-\uFF9F\々]/m

--- a/src/languages/ja/card/support.html
+++ b/src/languages/ja/card/support.html
@@ -453,6 +453,11 @@
           text_content.appendChild(ruby_elem);
 
           for (const segment of segments) {
+            if (field_settings.furigana === "replace") {
+              ruby_elem.appendChild(document.createTextNode(segment.reading))
+              continue
+            }
+
             ruby_elem.appendChild(document.createTextNode(segment.text));
 
             const rt_elem = document.createElement('rt');
@@ -501,7 +506,7 @@
           const popup_text =
             syntax_element.dict_form ||
             (syntax_element.reading || syntax_element.word_pre) +
-              syntax_element.word_post;
+            syntax_element.word_post;
 
           if (popup_text) {
             const popup_hover_box = document.createElement('div');
@@ -633,6 +638,67 @@
       }
     }
 
+    function migakuJapaneseDisplayTypeToFieldSettings(displayType) {
+      switch (displayType) {
+        case "hover":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'no',
+            pitch_shapes: 'no',
+            furigana: 'hover',
+          }
+        case "reading":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'no',
+            pitch_shapes: 'no',
+            furigana: 'replace',
+          }
+        case "kanji":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'no',
+            pitch_shapes: 'no',
+            furigana: 'no',
+          }
+        case "coloredkanji":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'yes',
+            pitch_shapes: 'no',
+            furigana: 'no',
+          }
+        case "kanjireading":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'no',
+            pitch_shapes: 'no',
+            furigana: 'yes',
+          }
+        case "coloredkanjireading":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'yes',
+            pitch_shapes: 'no',
+            furigana: 'yes',
+          }
+        case "coloredhover":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'hover',
+            pitch_shapes: 'no',
+            furigana: 'hover',
+          }
+        case "coloredreading":
+          return {
+            popup: 'yes',
+            pitch_coloring: 'yes',
+            pitch_shapes: 'no',
+            furigana: 'replace',
+          }
+      }
+    }
+
     function handleField(field) {
       // Ignore field if it doesn't contain syntax
       const syntax_test_re = /[\{\}\[\]]/;
@@ -640,24 +706,25 @@
         return;
       }
 
-      const field_settings = {
-        popup: field.getAttribute('data-popup') || 'no',
-        pitch_coloring: field.getAttribute('data-pitch-coloring') || 'no',
-        pitch_shapes: field.getAttribute('data-pitch-shapes') || 'no',
-        furigana: field.getAttribute('data-furigana') || 'no',
-      };
+      const field_settings =
+        field.hasAttribute('display-type')
+          ? migakuJapaneseDisplayTypeToFieldSettings(field.getAttribute('display-type'))
+          : {
+            popup: "no",
+            pitch_coloring: "no",
+            pitch_shapes: "no",
+            furigana: "no",
+          }
 
-      if (
-        field_settings.popup === 'yes' &&
-        field_settings.furigana === 'hover'
-      ) {
-        field_settings.furigana = 'hidden';
-      }
+      if (field.hasAttribute('data-popup')) field_settings.popup = field.getAttribute('data-popup');
+      if (field.hasAttribute('data-pitch-coloring')) field_settings.pitch_coloring = field.getAttribute('data-pitch-coloring');
+      if (field.hasAttribute('data-pitch-shapes')) field_settings.pitch_shapes = field.getAttribute('data-pitch-shapes');
+      if (field.hasAttribute('data-furigana')) field_settings.furigana = field.getAttribute('data-furigana');
 
       handleFieldTextNodes(field, field_settings);
     }
 
-    const fields = document.querySelectorAll('.field');
+    const fields = document.querySelectorAll('.field, .wrapped-japanese');
 
     for (field of fields) {
       handleField(field);

--- a/src/note_type_mgr.py
+++ b/src/note_type_mgr.py
@@ -18,10 +18,10 @@ FIELD_RE = re.compile(
 )
 SETTINGS_RE = re.compile(r"data-(.*?)=\"(.*?)\"")
 FORMAT_RE = re.compile(
-    r"<!--###MIGAKU (.*?) SUPPORT JS STARTS###.*?SUPPORT JS ENDS###-->", re.DOTALL
+    r"<!--###MIGAKU (.*?) SUPPORT JS STARTS###.*?SUPPORT JS ENDS###.*-->", re.DOTALL
 )
 STYLE_RE = re.compile(
-    r"/\*###MIGAKU (.*?) SUPPORT CSS STARTS###.*?SUPPORT CSS ENDS###\*/", re.DOTALL
+    r"/\*###MIGAKU (.*?) SUPPORT CSS STARTS###.*?SUPPORT CSS ENDS###.*\*/", re.DOTALL
 )
 
 


### PR DESCRIPTION
Fix two main issues that came up in the past day:

1. Fix issue with Japanese syntax regex:

It previously did not match 今 in "だったら 　今[いま;a] の オレ に できる[,できる;k2] こと[;o] を"

The issue was the part before 今, there was both a Japanese space
(\u3000) and a regular space, which confused the regex.

2. Add backwards compatibility with Migaku Japanese.

We implemented the replacement with the new JS in user notetypes in a way, that the JS and CSS of notetypes originally created with the "Migaku Japanese" add-on would also be overridden.
However the JS of the new add-on did not support the HTML of the Migaku Japanese add-on. See this 90884132e4a84e25400b5125b5a891d783d85a92 commit for the details.