### PR TITLE
Expose Reading in Migaku field maps

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -43,6 +43,7 @@ const selectorOptions = [
   { value: 'definitions', text: 'Definitions' },
   { value: 'exampleSentences', text: 'Example Sentences' },
   { value: 'notes', text: 'Notes' },
+  { value: 'reading', text: 'Reading' },
 ]
 
 function getSelectorField(editorField, settings) {


### PR DESCRIPTION
### Motivation
- Ensure the `reading` CardFields value is selectable in the editor Field Maps UI so note fields can be mapped to the Reading output produced by the add-on.

### Description
- Add the `Reading` option to the field-map selector in `src/editor/editor.js` by adding `{ value: 'reading', text: 'Reading' }` to the `selectorOptions` array.

### Testing
- Ran `npm test` (syntax parser tests) which completed with all tests passing (`16 passed, 0 failed`).
- Ran `node --check src/editor/editor.js` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc450cf4608333af7ee08064b8575e)